### PR TITLE
Fixed typo on command

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -63,7 +63,7 @@ sudo chmod 644 $deskpi_lite_svc
 log_action_msg "DeskPi Lite Service Load module." 
 sudo systemctl daemon-reload
 sudo systemctl enable $deskpi_daemon.service
-sudo systemctl restartt $deskpi_daemon.service
+sudo systemctl restart $deskpi_daemon.service
 
 # Finished 
 log_success_msg "DeskPi Lite Driver installation finished successfully." 


### PR DESCRIPTION
I noticed a typo in a command when installing on my system:

```bash
dwc2 has been setting up successfully.
DeskPi lite safe shutdown service.
DeskPi Lite Safe Shutdown Service configuration finished..
DeskPi Lite Service Load module..
Created symlink /etc/systemd/system/multi-user.target.wants/deskpilite.service → /lib/systemd/system/
deskpilite.service.
Unknown command verb restartt.
DeskPi Lite Driver installation finished successfully..
System will reboot in 5 seconds to take effect..
```

There is a double `t` in restart so this corrects that.