### PR TITLE
update config.txt paths for bookworm

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -20,8 +20,8 @@ fi
 
 # adding dtoverlay to enable dwc2 on host mode.
 log_action_msg "Enable dwc2 on Host Mode"
-sudo sed -i '/dtoverlay=dwc2*/d' /boot/config.txt 
-sudo sed -i '$a\dtoverlay=dwc2,dr_mode=host' /boot/config.txt 
+sudo sed -i '/dtoverlay=dwc2*/d' /boot/firmware/config.txt 
+sudo sed -i '$a\dtoverlay=dwc2,dr_mode=host' /boot/firmware/config.txt 
 if [ $? -eq 0 ]; then
    log_action_msg "dwc2 has been setting up successfully"
 fi

--- a/install.sh
+++ b/install.sh
@@ -63,7 +63,7 @@ sudo chmod 644 $deskpi_lite_svc
 log_action_msg "DeskPi Lite Service Load module." 
 sudo systemctl daemon-reload
 sudo systemctl enable $deskpi_daemon.service
-sudo systemctl restartt $deskpi_daemon.service
+sudo systemctl restart $deskpi_daemon.service
 
 # Finished 
 log_success_msg "DeskPi Lite Driver installation finished successfully." 

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # 
 . /lib/lsb/init-functions
+
+if [ "$(id -u)" -ne 0 ]; then echo "Please run as root." >&2; exit 1; fi
+
 sudo apt-get update && sudo apt-get -y install git 
 
 TEMP=/tmp


### PR DESCRIPTION
As of bookworm release, RPi OS uses a new location for the config.txt

change boot/config.txt -> boot/firmware/config.txt